### PR TITLE
Draft ietf httpbis p1 messaging 09

### DIFF
--- a/lib/Plack/Middleware/Auth/OAuth2/ProtectedResource.pm
+++ b/lib/Plack/Middleware/Auth/OAuth2/ProtectedResource.pm
@@ -69,12 +69,12 @@ sub call {
         if ($_->isa("OAuth::Lite2::Server::Error")) {
 
             my @params;
-            push(@params, sprintf(q{realm='%s'}, $self->{realm}))
+            push(@params, sprintf(q{realm="%s"}, $self->{realm}))
                 if $self->{realm};
-            push(@params, sprintf(q{error='%s'}, $_->type));
-            push(@params, sprintf(q{error-desc='%s'}, $_->description))
+            push(@params, sprintf(q{error="%s"}, $_->type));
+            push(@params, sprintf(q{error_description="%s"}, $_->description))
                 if $_->description;
-            push(@params, sprintf(q{error-uri='%s'}, $self->{error_uri}))
+            push(@params, sprintf(q{error_uri="%s"}, $self->{error_uri}))
                 if $self->{error_uri};
             # push(@params, sprintf(q{scope='%s'}, $_->scope))
             #     if $_->scope;

--- a/t/030_server/protected_resource/middleware.t
+++ b/t/030_server/protected_resource/middleware.t
@@ -86,7 +86,7 @@ $req->header("Authorization" => sprintf(q{OAuth %s}, 'invalid_access_token'));
 $res = &request($req);
 ok(!$res->is_success, 'request should fail');
 is($res->code, 401, 'invalid access token');
-is($res->header("WWW-Authenticate"), q{OAuth realm='resource.example.org', error='invalid_token'}, 'invalid access token');
+is($res->header("WWW-Authenticate"), q{OAuth realm="resource.example.org", error="invalid_token"}, 'invalid access token');
 
 sleep 2;
 $req = HTTP::Request->new("GET" => q{http://example.org/});
@@ -94,7 +94,7 @@ $req->header("Authorization" => sprintf(q{OAuth %s}, $access_token2->token));
 $res = &request($req);
 ok(!$res->is_success, 'request should fail');
 is($res->code, 401, 'expired access token');
-is($res->header("WWW-Authenticate"), q{OAuth realm='resource.example.org', error='expired_token'}, 'expired token');
+is($res->header("WWW-Authenticate"), q{OAuth realm="resource.example.org", error="expired_token"}, 'expired token');
 
 
 $req = HTTP::Request->new("GET" => q{http://example.org/});
@@ -102,14 +102,14 @@ $req->header("Authorization" => sprintf(q{OAuth %s}, $access_token3->token));
 $res = &request($req);
 ok(!$res->is_success, 'request should fail');
 is($res->code, 401, 'invalid client');
-is($res->header("WWW-Authenticate"), q{OAuth realm='resource.example.org', error='invalid_token'}, 'invalid client');
+is($res->header("WWW-Authenticate"), q{OAuth realm="resource.example.org", error="invalid_token"}, 'invalid client');
 
 $req = HTTP::Request->new("GET" => q{http://example.org/});
 $req->header("Authorization" => sprintf(q{OAuth %s}, $access_token4->token));
 $res = &request($req);
 ok(!$res->is_success, 'request should fail');
 is($res->code, 401, 'invalid client');
-is($res->header("WWW-Authenticate"), q{OAuth realm='resource.example.org', error='invalid_token'}, 'invalid client');
+is($res->header("WWW-Authenticate"), q{OAuth realm="resource.example.org", error="invalid_token"}, 'invalid client');
 
 $req = HTTP::Request->new("GET" => q{http://example.org/});
 $req->header("Authorization" => sprintf(q{OAuth %s}, $access_token->token));


### PR DESCRIPTION
Hi, Ishikawa-san found two bugs on WWW-Authenticate header.
1. "error-desc" should be "error_description" and "error-uri" should be "error_uri". Please see more detail at http://tools.ietf.org/html/draft-ietf-oauth-v2-10#page-32
2. quoted-string should be double-quoted, not single-quoted. Please see more detail at http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-09#page-10.

Please review my branch and pull it.
