### PR TITLE
updated to draft27 spec

### DIFF
--- a/lib/OAuth/Lite2/ParamMethod/AuthHeader.pm
+++ b/lib/OAuth/Lite2/ParamMethod/AuthHeader.pm
@@ -51,7 +51,7 @@ Returns true if passed L<Plack::Request> object is matched for the type of this 
 sub match {
     my ($self, $req) = @_;
     my $header = $req->header("Authorization");
-    return ($header && $header =~ /^\s*OAuth\s+(.+)$/);
+    return ($header && $header =~ /^\s*(OAuth|Bearer)\s+(.+)$/);
 }
 
 =head2 parse( $plack_request )
@@ -65,8 +65,8 @@ Parse the L<Plack::Request>, and returns access token and oauth parameters.
 sub parse {
     my ($self, $req) = @_;
     my $header = $req->header("Authorization");
-    $header =~ s/^\s*OAuth\s+([^\s\,]+)//;
-    my $token = $1;
+    $header =~ s/^\s*(OAuth|Bearer)\s+([^\s\,]+)//;
+    my $token = $2;
     my $params = Hash::MultiValue->new;
     if ($header) {
         $header =~ s/^\s*\,\s*//;
@@ -125,7 +125,7 @@ sub build_request {
     } else {
         $headers = HTTP::Headers->new;
     }
-    my $auth_header = sprintf(q{OAuth %s}, $args{token});
+    my $auth_header = sprintf(q{Bearer %s}, $args{token});
     $auth_header .= ", " . join(", ", @pairs) if @pairs > 0;
     $headers->header(Authorization => $auth_header);
 
@@ -147,6 +147,22 @@ sub build_request {
         my $req = HTTP::Request->new($method, $args{url}, $headers, $content);
         return $req;
     }
+}
+
+=head2 is_legacy( $plack_request )
+
+Returns true if passed L<Plack::Request> object is based draft version 10.
+
+    if ( $meth->is_legacy( $plack_request ) ) {
+        ...
+    }
+
+=cut
+
+sub is_legacy {
+    my ($self, $req) = @_;
+    my $header = $req->header("Authorization");
+    return ($header && $header =~ /^\s*OAuth\s+(.+)$/);
 }
 
 =head1 SEE ALSO

--- a/lib/OAuth/Lite2/ParamMethod/FormEncodedBody.pm
+++ b/lib/OAuth/Lite2/ParamMethod/FormEncodedBody.pm
@@ -54,7 +54,7 @@ sub match {
          ||  $method eq 'put'
          ||  $method eq 'delete')
          && $req->content_type eq 'application/x-www-form-urlencoded'
-         && $req->body_parameters->{oauth_token});
+         && ($req->body_parameters->{oauth_token} || $req->body_parameters->{access_token}));
 }
 
 =head2 parse( $plack_request )
@@ -68,8 +68,12 @@ Parse the L<Plack::Request>, and returns access token and oauth parameters.
 sub parse {
     my ($self, $req) = @_;
     my $params = $req->body_parameters;
-    my $token = $params->{oauth_token};
-    $params->remove('oauth_token');
+    my $token = $params->{access_token};
+    $params->remove('access_token');
+    if($params->{oauth_token}){
+        $token = $params->{oauth_token};
+        $params->remove('oauth_token');
+    }
     return ($token, $params);
 }
 
@@ -107,7 +111,7 @@ sub build_request {
     } else {
 
         my $oauth_params = $args{oauth_params} || {};
-        $oauth_params->{oauth_token} = $args{token};
+        $oauth_params->{access_token} = $args{token};
 
         my $headers = $args{headers};
         if (defined $headers) {
@@ -135,6 +139,22 @@ sub build_request {
         my $req = HTTP::Request->new($method, $args{url}, $headers, $content);
         return $req;
     }
+}
+
+=head2 is_legacy( $plack_request )
+
+Returns true if passed L<Plack::Request> object is based draft version 10.
+
+    if ( $meth->is_legacy( $plack_request ) ) {
+        ...
+    }
+
+=cut
+
+sub is_legacy {
+    my ($self, $req) = @_;
+    my $method = lc $req->method;
+    return ($req->body_parameters->{oauth_token});
 }
 
 =head1 SEE ALSO

--- a/lib/OAuth/Lite2/Server/Error.pm
+++ b/lib/OAuth/Lite2/Server/Error.pm
@@ -93,6 +93,8 @@ L<http://tools.ietf.org/html/draft-ietf-oauth-v2-09#section-5.2>
 
 =item OAuth::Lite2::Server::Error::ExpiredToken
 
+=item OAuth::Lite2::Server::Error::ExpiredTokenLegacy
+
 =item OAuth::Lite2::Server::Error::InvalidRequest
 
 =item OAuth::Lite2::Server::Error::InvalidToken
@@ -182,10 +184,16 @@ our @ISA = qw(OAuth::Lite2::Server::Error);
 sub code { 401 }
 sub type { "invalid_token" }
 
-package OAuth::Lite2::Server::Error::ExpiredToken;
+package OAuth::Lite2::Server::Error::ExpiredTokenLegacy;
 our @ISA = qw(OAuth::Lite2::Server::Error);
 sub code { 401 }
 sub type { "expired_token" }
+
+package OAuth::Lite2::Server::Error::ExpiredToken;
+our @ISA = qw(OAuth::Lite2::Server::Error);
+sub code { 401 }
+sub type { "invalid_token" }
+sub description { "The access token expired" }
 
 package OAuth::Lite2::Server::Error::InsufficientScope;
 our @ISA = qw(OAuth::Lite2::Server::Error);

--- a/lib/OAuth/Lite2/Server/GrantHandler/AuthorizationCode.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/AuthorizationCode.pm
@@ -46,6 +46,7 @@ sub handle_request {
             && $access_token->isa("OAuth::Lite2::Model::AccessToken"));
 
     my $res = {
+        token_type => 'bearer',
         access_token => $access_token->token,
     };
 

--- a/lib/OAuth/Lite2/Server/GrantHandler/ClientCredentials.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/ClientCredentials.pm
@@ -37,6 +37,7 @@ sub handle_request {
             && $access_token->isa("OAuth::Lite2::Model::AccessToken"));
 
     my $res = {
+        token_type => 'bearer',
         access_token => $access_token->token,
     };
     $res->{expires_in} = $access_token->expires_in

--- a/lib/OAuth/Lite2/Server/GrantHandler/Password.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/Password.pm
@@ -46,6 +46,7 @@ sub handle_request {
             && $access_token->isa("OAuth::Lite2::Model::AccessToken"));
 
     my $res = {
+        token_type => 'bearer',
         access_token => $access_token->token,
     };
     $res->{expires_in} = $access_token->expires_in

--- a/lib/OAuth/Lite2/Server/GrantHandler/RefreshToken.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/RefreshToken.pm
@@ -37,6 +37,7 @@ sub handle_request {
             && $access_token->isa("OAuth::Lite2::Model::AccessToken"));
 
     my $res = {
+        token_type => 'bearer',
         access_token => $access_token->token,
     };
     $res->{expires_in} = $access_token->expires_in

--- a/t/030_server/token_endpoint/authorization_code.t
+++ b/t/030_server/token_endpoint/authorization_code.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use lib 't/lib';
-use Test::More tests => 11;
+use Test::More tests => 12;
 
 use Plack::Request;
 use Try::Tiny;
@@ -43,6 +43,7 @@ sub test_success {
     };
 
     if(exists $expected->{token}) {
+        is($res->{token_type}, $expected->{token_type});
         is($res->{access_token}, $expected->{token});
     } else {
         ok(!$res->{access_token});
@@ -138,6 +139,7 @@ sub test_error {
     client_secret => q{secret_value},
     redirect_uri  => q{http://example.org/callback},
 }, {
+    token_type    => q{bearer},
     token         => q{access_token_0},
     expires_in    => q{3600},
     refresh_token => q{refresh_token_0},

--- a/t/030_server/token_endpoint/client_credentials.t
+++ b/t/030_server/token_endpoint/client_credentials.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use lib 't/lib';
-use Test::More tests => 11;
+use Test::More tests => 13;
 
 use Plack::Request;
 use Try::Tiny;
@@ -48,6 +48,7 @@ sub test_success {
     };
 
     if(exists $expected->{token}) {
+        is($res->{token_type}, $expected->{token_type});
         is($res->{access_token}, $expected->{token});
     } else {
         ok(!$res->{access_token});
@@ -95,6 +96,7 @@ sub test_error {
     client_id     => q{foo},
     client_secret => q{bar},
 }, {
+    token_type    => q{bearer},
     token         => q{access_token_0},
     expires_in    => q{3600},
     refresh_token => q{refresh_token_2},
@@ -105,6 +107,7 @@ sub test_error {
     client_id     => q{buz},
     client_secret => q{hoge},
 }, {
+    token_type    => q{bearer},
     token         => q{access_token_1},
     expires_in    => q{3600},
     refresh_token => q{refresh_token_3},

--- a/t/030_server/token_endpoint/password.t
+++ b/t/030_server/token_endpoint/password.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use lib 't/lib';
-use Test::More tests => 10;
+use Test::More tests => 11;
 
 use Plack::Request;
 use Try::Tiny;
@@ -42,6 +42,7 @@ sub test_success {
     };
 
     if(exists $expected->{token}) {
+        is($res->{token_type}, $expected->{token_type});
         is($res->{access_token}, $expected->{token});
     } else {
         ok(!$res->{access_token});
@@ -136,6 +137,7 @@ sub test_error {
     username      => q{user_1},
     password      => q{pass_1},
 }, {
+    token_type    => q{bearer},
     token         => q{access_token_0},
     expires_in    => q{3600},
     refresh_token => q{refresh_token_1},

--- a/t/030_server/token_endpoint/refresh.t
+++ b/t/030_server/token_endpoint/refresh.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use lib 't/lib';
-use Test::More tests => 9;
+use Test::More tests => 10;
 
 use Plack::Request;
 use Try::Tiny;
@@ -41,6 +41,7 @@ sub test_success {
     };
 
     if(exists $expected->{token}) {
+        is($res->{token_type}, $expected->{token_type});
         is($res->{access_token}, $expected->{token});
     } else {
         ok(!$res->{access_token});
@@ -117,6 +118,7 @@ sub test_error {
     client_secret => q{bar},
     refresh_token => $auth_info->refresh_token,
 }, {
+    token_type    => q{bearer},
     token         => q{access_token_0},
     expires_in    => q{3600},
     refresh_token => q{refresh_token_0},


### PR DESCRIPTION
I updated this to latest spec.

For legacy spec implementer(about draft 10), this branch supports backward compatibility.
- The protected resource determines whether a request is Legacy
- The appropriate error response along the request is returned
