### PR TITLE
Added support the HTTP Basic authentication scheme for client authN

### DIFF
--- a/lib/OAuth/Lite2/Client/ClientCredentials.pm
+++ b/lib/OAuth/Lite2/Client/ClientCredentials.pm
@@ -11,6 +11,7 @@ use Try::Tiny;
 use URI;
 use LWP::UserAgent;
 use HTTP::Request;
+use MIME::Base64 qw(encode_base64);
 
 use OAuth::Lite2;
 use OAuth::Lite2::Util qw(build_content);
@@ -169,6 +170,7 @@ sub get_access_token {
     my %args = Params::Validate::validate(@_, {
         scope        => { optional => 1 },
         uri          => { optional => 1 },
+        use_basic_schema    => { optional => 1 },
         # secret_type => { optional => 1 },
         # format      => { optional => 1 },
     });
@@ -182,10 +184,13 @@ sub get_access_token {
 
     my %params = (
         grant_type    => 'client_credentials',
-        client_id     => $self->{id},
-        client_secret => $self->{secret},
         # format      => $args{format},
     );
+
+    unless ($args{use_basic_schema}){
+        $params{client_id}      = $self->{id};
+        $params{client_secret}  = $self->{secret};
+    }
 
     $params{scope} = $args{scope}
         if $args{scope};
@@ -197,6 +202,8 @@ sub get_access_token {
     my $headers = HTTP::Headers->new;
     $headers->header("Content-Type" => q{application/x-www-form-urlencoded});
     $headers->header("Content-Length" => bytes::length($content));
+    $headers->header("Authorization" => sprintf(q{Basic %s}, encode_base64($self->{id}.":".$self->{secret},''))) 
+        if($args{use_basic_schema});
     my $req = HTTP::Request->new( POST => $args{uri}, $headers, $content );
 
     my $res = $self->{agent}->request($req);
@@ -229,6 +236,7 @@ sub refresh_access_token {
     my %args = Params::Validate::validate(@_, {
         refresh_token => 1,
         uri           => { optional => 1 },
+        use_basic_schema    => { optional => 1 },
         # secret_type => { optional => 1 },
         # format      => { optional => 1 },
     });
@@ -242,11 +250,14 @@ sub refresh_access_token {
 
     my %params = (
         grant_type    => 'refresh_token',
-        client_id     => $self->{id},
-        client_secret => $self->{secret},
         refresh_token => $args{refresh_token},
         # format        => $args{format},
     );
+
+    unless ($args{use_basic_schema}){
+        $params{client_id}      = $self->{id};
+        $params{client_secret}  = $self->{secret};
+    }
 
     # $params{secret_type} = $args{secret_type}
     #     if $args{secret_type};
@@ -255,6 +266,8 @@ sub refresh_access_token {
     my $headers = HTTP::Headers->new;
     $headers->header("Content-Type" => q{application/x-www-form-urlencoded});
     $headers->header("Content-Length" => bytes::length($content));
+    $headers->header("Authorization" => sprintf(q{Basic %s}, encode_base64($self->{id}.":".$self->{secret},''))) 
+        if($args{use_basic_schema});
     my $req = HTTP::Request->new( POST => $args{uri}, $headers, $content );
 
     my $res = $self->{agent}->request($req);

--- a/lib/OAuth/Lite2/Client/WebServer.pm
+++ b/lib/OAuth/Lite2/Client/WebServer.pm
@@ -13,6 +13,7 @@ use LWP::UserAgent;
 use HTTP::Request;
 use HTTP::Headers;
 use Try::Tiny;
+use MIME::Base64 qw(encode_base64);
 
 use OAuth::Lite2;
 use OAuth::Lite2::Util qw(build_content);
@@ -243,9 +244,10 @@ sub get_access_token {
     my $self = shift;
 
     my %args = Params::Validate::validate(@_, {
-        code         => 1,
-        redirect_uri => 1,
-        uri          => { optional => 1 },
+        code            => 1,
+        redirect_uri    => 1,
+        uri             => { optional => 1 },
+        use_basic_schema    => { optional => 1 },
         # secret_type => { optional => 1 },
         # format      => { optional => 1 },
     });
@@ -259,12 +261,15 @@ sub get_access_token {
 
     my %params = (
         grant_type    => 'authorization_code',
-        client_id     => $self->{id},
-        client_secret => $self->{secret},
         code          => $args{code},
         redirect_uri  => $args{redirect_uri},
         # format      => $args{format},
     );
+
+    unless ($args{use_basic_schema}){
+        $params{client_id}      = $self->{id};
+        $params{client_secret}  = $self->{secret};
+    }
 
     # $params{secret_type} = $args{secret_type}
     #    if $args{secret_type};
@@ -273,6 +278,8 @@ sub get_access_token {
     my $headers = HTTP::Headers->new;
     $headers->header("Content-Type" => q{application/x-www-form-urlencoded});
     $headers->header("Content-Length" => bytes::length($content));
+    $headers->header("Authorization" => sprintf(q{Basic %s}, encode_base64($self->{id}.":".$self->{secret},''))) 
+        if($args{use_basic_schema});
     my $req = HTTP::Request->new( POST => $args{uri}, $headers, $content );
 
     my $res = $self->{agent}->request($req);
@@ -309,6 +316,7 @@ sub refresh_access_token {
         # secret_type => { optional => 1 },
         # format      => { optional => 1 },
         uri           => { optional => 1 },
+        use_basic_schema    => { optional => 1 },
     });
 
     unless (exists $args{uri}) {
@@ -320,11 +328,14 @@ sub refresh_access_token {
 
     my %params = (
         grant_type    => 'refresh_token',
-        client_id     => $self->{id},
-        client_secret => $self->{secret},
         refresh_token => $args{refresh_token},
         # format      => $args{format},
     );
+
+    unless ($args{use_basic_schema}){
+        $params{client_id}      = $self->{id};
+        $params{client_secret}  = $self->{secret};
+    }
 
     # $params{secret_type} = $args{secret_type}
     #   if $args{secret_type};
@@ -333,6 +344,8 @@ sub refresh_access_token {
     my $headers = HTTP::Headers->new;
     $headers->header("Content-Type" => q{application/x-www-form-urlencoded});
     $headers->header("Content-Length" => bytes::length($content));
+    $headers->header("Authorization" => sprintf(q{Basic %s}, encode_base64($self->{id}.":".$self->{secret},''))) 
+        if($args{use_basic_schema});
     my $req = HTTP::Request->new( POST => $args{uri}, $headers, $content );
 
     my $res = $self->{agent}->request($req);

--- a/lib/OAuth/Lite2/Server/GrantHandler/AuthorizationCode.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/AuthorizationCode.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use parent 'OAuth::Lite2::Server::GrantHandler';
 use OAuth::Lite2::Server::Error;
+use OAuth::Lite2::ParamMethod::AuthHeader;
 use Carp ();
 
 sub handle_request {
@@ -12,7 +13,9 @@ sub handle_request {
 
     my $req = $dh->request;
 
-    my $client_id = $req->param("client_id");
+    my $parser = OAuth::Lite2::ParamMethod::AuthHeader->new;
+    my $header_credentials = $parser->basic_credentials($req);
+    my $client_id = ($header_credentials->{client_id}) ? $header_credentials->{client_id} : $req->param("client_id");
 
     my $code = $req->param("code")
         or OAuth::Lite2::Server::Error::InvalidRequest->throw(

--- a/lib/OAuth/Lite2/Server/GrantHandler/ClientCredentials.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/ClientCredentials.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use parent 'OAuth::Lite2::Server::GrantHandler';
 use OAuth::Lite2::Server::Error;
+use OAuth::Lite2::ParamMethod::AuthHeader;
 use Carp ();
 
 sub handle_request {
@@ -12,8 +13,10 @@ sub handle_request {
 
     my $req = $dh->request;
 
-    my $client_id     = $req->param("client_id");
-    my $client_secret = $req->param("client_secret");
+    my $parser = OAuth::Lite2::ParamMethod::AuthHeader->new;
+    my $header_credentials = $parser->basic_credentials($req);
+    my $client_id = ($header_credentials->{client_id}) ? $header_credentials->{client_id} : $req->param("client_id");
+    my $client_secret = ($header_credentials->{client_secret}) ? $header_credentials->{client_secret} : $req->param("client_secret");
 
     my $user_id = $dh->get_client_user_id($client_id, $client_secret);
     OAuth::Lite2::Server::Error::InvalidClient->throw unless defined $user_id;

--- a/lib/OAuth/Lite2/Server/GrantHandler/Password.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/Password.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use parent 'OAuth::Lite2::Server::GrantHandler';
 use OAuth::Lite2::Server::Error;
+use OAuth::Lite2::ParamMethod::AuthHeader;
 use Carp ();
 
 sub handle_request {
@@ -12,7 +13,9 @@ sub handle_request {
 
     my $req = $dh->request;
 
-    my $client_id = $req->param("client_id");
+    my $parser = OAuth::Lite2::ParamMethod::AuthHeader->new;
+    my $header_credentials = $parser->basic_credentials($req);
+    my $client_id = ($header_credentials->{client_id}) ? $header_credentials->{client_id} : $req->param("client_id");
 
     my $username = $req->param("username");
     OAuth::Lite2::Server::Error::InvalidRequest->throw(

--- a/lib/OAuth/Lite2/Server/GrantHandler/RefreshToken.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/RefreshToken.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use parent 'OAuth::Lite2::Server::GrantHandler';
 use OAuth::Lite2::Server::Error;
+use OAuth::Lite2::ParamMethod::AuthHeader;
 use Carp ();
 
 sub handle_request {
@@ -12,8 +13,10 @@ sub handle_request {
 
     my $req = $dh->request;
 
-    my $client_id     = $req->param("client_id");
-    my $client_secret = $req->param("client_secret");
+    my $parser = OAuth::Lite2::ParamMethod::AuthHeader->new;
+    my $header_credentials = $parser->basic_credentials($req);
+    my $client_id = ($header_credentials->{client_id}) ? $header_credentials->{client_id} : $req->param("client_id");
+    my $client_secret = ($header_credentials->{client_secret}) ? $header_credentials->{client_secret} : $req->param("client_secret");
 
     my $refresh_token = $req->param("refresh_token")
         or OAuth::Lite2::Server::Error::InvalidRequest->throw(

--- a/t/040_unit/client_credentials.t
+++ b/t/040_unit/client_credentials.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use lib 't/lib';
-use Test::More tests => 14;
+use Test::More tests => 28;
 
 use TestDataHandler;
 use OAuth::Lite2::Server::Endpoint::Token;
@@ -37,9 +37,22 @@ is($res->refresh_token, q{refresh_token_0});
 is($res->expires_in, q{3600});
 ok(!$res->access_token_secret);
 ok(!$res->scope);
+$res = $client->get_access_token(use_basic_schema => 1);
+ok($res, q{response should be not undef});
+is($res->access_token, q{access_token_1});
+is($res->refresh_token, q{refresh_token_1});
+is($res->expires_in, q{3600});
+ok(!$res->access_token_secret);
+ok(!$res->scope);
 
 $res = $client->refresh_access_token(
     refresh_token => q{invalid_refresh_token},
+);
+ok(!$res, q{response should be undef});
+is($client->errstr, q{invalid_grant}, q{refresh-token should be invalid});
+$res = $client->refresh_access_token(
+    refresh_token => q{invalid_refresh_token},
+    use_basic_schema => 1,
 );
 ok(!$res, q{response should be undef});
 is($client->errstr, q{invalid_grant}, q{refresh-token should be invalid});
@@ -48,7 +61,17 @@ $res = $client->refresh_access_token(
     refresh_token => q{refresh_token_0},
 );
 ok($res, q{response should be not undef});
-is($res->access_token, q{access_token_1});
+is($res->access_token, q{access_token_2});
+is($res->refresh_token, q{refresh_token_0});
+is($res->expires_in, q{3600});
+ok(!$res->access_token_secret);
+ok(!$res->scope);
+$res = $client->refresh_access_token(
+    refresh_token => q{refresh_token_0},
+    use_basic_schema => 1,
+);
+ok($res, q{response should be not undef});
+is($res->access_token, q{access_token_3});
 is($res->refresh_token, q{refresh_token_0});
 is($res->expires_in, q{3600});
 ok(!$res->access_token_secret);

--- a/t/040_unit/common.t
+++ b/t/040_unit/common.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use lib 't/lib';
-use Test::More tests => 8;
+use Test::More tests => 16;
 
 use TestDataHandler;
 use OAuth::Lite2::Server::Endpoint::Token;
@@ -47,6 +47,13 @@ $res = $invalid_client1->get_access_token(
 );
 ok(!$res, q{response should be undef});
 is($invalid_client1->errstr, q{unsupported_grant_type}, q{tried to use unsupported grant-type});
+$res = $invalid_client1->get_access_token(
+    username => q{buz},
+    password => q{hoge},
+    use_basic_schema => 1,
+);
+ok(!$res, q{response should be undef});
+is($invalid_client1->errstr, q{unsupported_grant_type}, q{tried to use unsupported grant-type});
 
 my $invalid_client2 = OAuth::Lite2::Client::WebServer->new(
     id                => q{invalid},
@@ -61,6 +68,13 @@ $res = $invalid_client2->get_access_token(
 );
 ok(!$res, q{response should be undef});
 is($invalid_client2->errstr, q{invalid_client}, q{invalid client_id});
+$res = $invalid_client2->get_access_token(
+    code         => q{buz},
+    redirect_uri => q{http://example.org/callback},
+    use_basic_schema => 1,
+);
+ok(!$res, q{response should be undef});
+is($invalid_client2->errstr, q{invalid_client}, q{invalid client_id});
 
 my $invalid_client3 = OAuth::Lite2::Client::WebServer->new(
     id                => q{foo},
@@ -72,6 +86,13 @@ my $invalid_client3 = OAuth::Lite2::Client::WebServer->new(
 $res = $invalid_client3->get_access_token(
     code         => q{buz},
     redirect_uri => q{http://example.org/callback},
+);
+ok(!$res, q{response should be undef});
+is($invalid_client3->errstr, q{invalid_client}, q{invalid client_secret});
+$res = $invalid_client3->get_access_token(
+    code                => q{buz},
+    redirect_uri        => q{http://example.org/callback},
+    use_basic_schema    => 1,
 );
 ok(!$res, q{response should be undef});
 is($invalid_client3->errstr, q{invalid_client}, q{invalid client_secret});
@@ -90,5 +111,11 @@ $res = $invalid_client4->get_access_token(
 );
 ok(!$res, q{response should be undef});
 is($invalid_client4->errstr, q{invalid_client}, q{This client isn't allowed to use this grant-type});
-
+$res = $invalid_client4->get_access_token(
+    code         => q{buz},
+    redirect_uri => q{http://example.org/callback},
+    use_basic_schema => 1,
+);
+ok(!$res, q{response should be undef});
+is($invalid_client4->errstr, q{invalid_client}, q{This client isn't allowed to use this grant-type});
 

--- a/t/040_unit/username.t
+++ b/t/040_unit/username.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use lib 't/lib';
-use Test::More tests => 18;
+use Test::More tests => 36;
 
 use TestDataHandler;
 use OAuth::Lite2::Server::Endpoint::Token;
@@ -36,10 +36,24 @@ $res = $client->get_access_token(
 );
 ok(!$res, q{response should be undef});
 is($client->errstr, q{invalid_grant}, q{user should be invalid});
+$res = $client->get_access_token(
+    username => q{invalid},
+    password => q{hoge},
+    use_basic_schema => 1,
+);
+ok(!$res, q{response should be undef});
+is($client->errstr, q{invalid_grant}, q{user should be invalid});
 
 $res = $client->get_access_token(
     username => q{buz},
     password => q{invalid},
+);
+ok(!$res, q{response should be undef});
+is($client->errstr, q{invalid_grant}, q{user should be invalid});
+$res = $client->get_access_token(
+    username => q{buz},
+    password => q{invalid},
+    use_basic_schema => 1,
 );
 ok(!$res, q{response should be undef});
 is($client->errstr, q{invalid_grant}, q{user should be invalid});
@@ -54,9 +68,26 @@ is($res->refresh_token, q{refresh_token_0});
 is($res->expires_in, q{3600});
 ok(!$res->access_token_secret);
 ok(!$res->scope);
+$res = $client->get_access_token(
+    username => q{buz},
+    password => q{hoge},
+    use_basic_schema => 1,
+);
+ok($res, q{response should be not undef});
+is($res->access_token, q{access_token_1});
+is($res->refresh_token, q{refresh_token_1});
+is($res->expires_in, q{3600});
+ok(!$res->access_token_secret);
+ok(!$res->scope);
 
 $res = $client->refresh_access_token(
     refresh_token => q{invalid_refresh_token},
+);
+ok(!$res, q{response should be undef});
+is($client->errstr, q{invalid_grant}, q{refresh-token should be invalid});
+$res = $client->refresh_access_token(
+    refresh_token => q{invalid_refresh_token},
+    use_basic_schema => 1,
 );
 ok(!$res, q{response should be undef});
 is($client->errstr, q{invalid_grant}, q{refresh-token should be invalid});
@@ -65,7 +96,17 @@ $res = $client->refresh_access_token(
     refresh_token => q{refresh_token_0},
 );
 ok($res, q{response should be not undef});
-is($res->access_token, q{access_token_1});
+is($res->access_token, q{access_token_2});
+is($res->refresh_token, q{refresh_token_0});
+is($res->expires_in, q{3600});
+ok(!$res->access_token_secret);
+ok(!$res->scope);
+$res = $client->refresh_access_token(
+    refresh_token => q{refresh_token_0},
+    use_basic_schema => 1,
+);
+ok($res, q{response should be not undef});
+is($res->access_token, q{access_token_3});
 is($res->refresh_token, q{refresh_token_0});
 is($res->expires_in, q{3600});
 ok(!$res->access_token_secret);


### PR DESCRIPTION
I added a support of Basic authN scheme for the client authN at Token Endpoint.

[2.3.1.  Client Password - The OAuth 2.0 Authorization Framework](http://tools.ietf.org/html/rfc6749#section-2.3.1)

> The authorization server MUST support the HTTP Basic authentication scheme for authenticating clients that were issued a client password.
