### PR TITLE
It fails on test @ perl5.18

### DIFF
--- a/t/010_core/formatter.t
+++ b/t/010_core/formatter.t
@@ -1,8 +1,6 @@
 use strict;
 use warnings;
-
-use Test::More tests => 30;
-
+use Test::More tests => 31;
 use OAuth::Lite2::Formatters;
 use Try::Tiny;
 
@@ -41,8 +39,10 @@ my $params1 = {
 TEST_JSON: {
     is($json->name, "json");
     is($json->type, "application/json");
-    #is($json->format($params1), '{"expires_in":3600,"refresh_token":"bar","access_token_secret":"buz","access_token":"foo"}');
-
+    SKIP: {
+        skip "It fails because of Perl 5.18.x Hash Randomization", 1 if $^V =~ /v5.18/;
+        is($json->format($params1), '{"expires_in":3600,"refresh_token":"bar","access_token_secret":"buz","access_token":"foo"}');
+    }
     my $parsed = $json->parse('{"expires_in":3600,"refresh_token":"bar","access_token_secret":"buz","access_token":"foo"}');
 
     is($parsed->{access_token}, q{foo});
@@ -62,8 +62,11 @@ TEST_JSON: {
 TEST_XML: {
     is($xml->name, "xml");
     is($xml->type, "application/xml");
-    is($xml->format($params1), '<?xml version="1.0" encoding="UTF-8"?><OAuth><expires_in>3600</expires_in><refresh_token>bar</refresh_token><access_token_secret>buz</access_token_secret><access_token>foo</access_token></OAuth>');
+    SKIP: {
+        skip "It fails because of Perl 5.18.x Hash Randomization", 1 if $^V =~ /v5.18/;
+        is($xml->format($params1), '<?xml version="1.0" encoding="UTF-8"?><OAuth><expires_in>3600</expires_in><refresh_token>bar</refresh_token><access_token_secret>buz</access_token_secret><access_token>foo</access_token></OAuth>');
 
+    }
     my $parsed = $xml->parse('<?xml version="1.0" encoding="UTF-8"?><OAuth><expires_in>3600</expires_in><refresh_token>bar</refresh_token><access_token_secret>buz</access_token_secret><access_token>foo</access_token></OAuth>');
 
     is($parsed->{access_token}, q{foo});
@@ -83,8 +86,10 @@ TEST_XML: {
 TEST_FORM: {
     is($form->name, "form");
     is($form->type, "application/x-www-form-urlencoded");
-    is($form->format($params1), 'access_token=foo&access_token_secret=buz&expires_in=3600&refresh_token=bar');
-
+    SKIP: {
+        skip "It fails because of Perl 5.18.x Hash Randomization", 1 if $^V =~ /v5.18/;
+        is($form->format($params1), 'access_token=foo&access_token_secret=buz&expires_in=3600&refresh_token=bar');
+    }
     my $parsed = $form->parse('access_token=foo&access_token_secret=buz&expires_in=3600&refresh_token=bar');
 
     is($parsed->{access_token}, q{foo});

--- a/t/010_core/param_methods.t
+++ b/t/010_core/param_methods.t
@@ -160,7 +160,10 @@ TEST_AUTH_HEADER: {
             buz => 'hoge',
         },
     );
-    is($req->uri, q{http://example.org/resource?buz=hoge&foo=bar});
+    SKIP: {
+        skip "It fails because of perl 5.18.x Hash Randomization", 1 if $^V =~ /^v5\.18/;
+        is($req->uri, q{http://example.org/resource?buz=hoge&foo=bar});
+    }
     is($req->header("Authorization"), q{Bearer access_token_value});
     is(uc $req->method, q{GET});
     ok(!$req->content);
@@ -193,7 +196,10 @@ TEST_AUTH_HEADER: {
             buz => 'hoge',
         },
     );
-    is($req->uri, q{http://example.org/resource?buz=hoge&foo=bar});
+    SKIP: {
+        skip "It fails because of perl 5.18.x Hash Randomization", 1 if $^V =~ /^v5\.18/;
+        is($req->uri, q{http://example.org/resource?buz=hoge&foo=bar});
+    }
     is($req->header("Authorization"), q{Bearer access_token_value});
     is(uc $req->method, q{GET});
     ok(!$req->content);


### PR DESCRIPTION
http://search.cpan.org/dist/perl-5.18.0/pod/perldelta.pod#Hash_randomization

Hash randomization sucks. OAuth::Lite2 rules.
