### PR TITLE
Force numerical context for 'expires_in'.

### DIFF
--- a/lib/OAuth/Lite2/Formatter/XML.pm
+++ b/lib/OAuth/Lite2/Formatter/XML.pm
@@ -15,7 +15,7 @@ sub format {
     my ($self, $hash) = @_;
     my $xml = '<?xml version="1.0" encoding="UTF-8"?>';
     $xml .= '<OAuth>';
-    for my $key ( keys %$hash ) {
+    for my $key ( sort keys %$hash ) {
         $xml .= sprintf(q{<%s>%s</%s>},
             $key,
             $hash->{$key},

--- a/lib/OAuth/Lite2/ParamMethod/AuthHeader.pm
+++ b/lib/OAuth/Lite2/ParamMethod/AuthHeader.pm
@@ -114,7 +114,7 @@ sub build_request {
     my @pairs = sort map { sprintf q{%s="%s"},
         encode_param($_),
         encode_param($oauth_params->{$_})
-    } keys %$oauth_params;
+    } sort keys %$oauth_params;
 
     my $params  = $args{params} || {};
     my $method  = uc $args{method};

--- a/lib/OAuth/Lite2/Server/GrantHandler/AuthorizationCode.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/AuthorizationCode.pm
@@ -53,7 +53,7 @@ sub handle_request {
         access_token => $access_token->token,
     };
 
-    $res->{expires_in} = $access_token->expires_in
+    $res->{expires_in} = int($access_token->expires_in)
         if $access_token->expires_in;
     $res->{refresh_token} = $auth_info->refresh_token
         if $auth_info->refresh_token;

--- a/lib/OAuth/Lite2/Server/GrantHandler/ClientCredentials.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/ClientCredentials.pm
@@ -43,7 +43,7 @@ sub handle_request {
         token_type => 'Bearer',
         access_token => $access_token->token,
     };
-    $res->{expires_in} = $access_token->expires_in
+    $res->{expires_in} = int($access_token->expires_in)
         if $access_token->expires_in;
     $res->{refresh_token} = $auth_info->refresh_token
         if $auth_info->refresh_token;

--- a/lib/OAuth/Lite2/Server/GrantHandler/Password.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/Password.pm
@@ -52,7 +52,7 @@ sub handle_request {
         token_type => 'Bearer',
         access_token => $access_token->token,
     };
-    $res->{expires_in} = $access_token->expires_in
+    $res->{expires_in} = int($access_token->expires_in)
         if $access_token->expires_in;
     $res->{refresh_token} = $auth_info->refresh_token
         if $auth_info->refresh_token;

--- a/lib/OAuth/Lite2/Server/GrantHandler/RefreshToken.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/RefreshToken.pm
@@ -43,7 +43,7 @@ sub handle_request {
         token_type => 'Bearer',
         access_token => $access_token->token,
     };
-    $res->{expires_in} = $access_token->expires_in
+    $res->{expires_in} = int($access_token->expires_in)
         if $access_token->expires_in;
     $res->{refresh_token} = $auth_info->refresh_token
         if $auth_info->refresh_token;

--- a/lib/OAuth/Lite2/Util.pm
+++ b/lib/OAuth/Lite2/Util.pm
@@ -76,7 +76,7 @@ sub build_content {
     $params = $params->as_hashref_mixed
         if blessed($params) && $params->isa('Hash::MultiValue');
     my @pairs;
-    for my $key (keys %$params) {
+    for my $key (sort keys %$params) {
         my $k = encode_param($key);
         my $v = $params->{$key};
         if (ref($v) eq 'ARRAY') {

--- a/t/010_core/formatter.t
+++ b/t/010_core/formatter.t
@@ -62,7 +62,7 @@ TEST_JSON: {
 TEST_XML: {
     is($xml->name, "xml");
     is($xml->type, "application/xml");
-    is($xml->format($params1), '<?xml version="1.0" encoding="UTF-8"?><OAuth><expires_in>3600</expires_in><refresh_token>bar</refresh_token><access_token_secret>buz</access_token_secret><access_token>foo</access_token></OAuth>');
+    is($xml->format($params1), '<?xml version="1.0" encoding="UTF-8"?><OAuth><access_token>foo</access_token><access_token_secret>buz</access_token_secret><expires_in>3600</expires_in><refresh_token>bar</refresh_token></OAuth>');
 
     my $parsed = $xml->parse('<?xml version="1.0" encoding="UTF-8"?><OAuth><expires_in>3600</expires_in><refresh_token>bar</refresh_token><access_token_secret>buz</access_token_secret><access_token>foo</access_token></OAuth>');
 


### PR DESCRIPTION
Depending on where the 'expires_in' value comes from, and depending on the
JSON encoder, it is possible that the returned value is put inside
quotes.

Also while there add some keys sorting when processing hash so that the output result remains the same when testing.

Thank you for your work this module and considering my patches.
